### PR TITLE
Fix small typo in import

### DIFF
--- a/vwgconnect/helper/token.py
+++ b/vwgconnect/helper/token.py
@@ -6,7 +6,7 @@ Helper functions for token handling.
 
 from datetime import datetime
 import jwt
-from vwgconnect.strings.globals import SIG_VERIFY, EXPIRY
+from vwgconnect.string.globals import SIG_VERIFY, EXPIRY
 
 
 def decode_token(token) -> dict:


### PR DESCRIPTION
So the `example.py` works again :)