### PR TITLE
Let climatisation_time_left and charging_time_left return minutes

### DIFF
--- a/skodaconnect/dashboard.py
+++ b/skodaconnect/dashboard.py
@@ -1265,7 +1265,7 @@ def create_instruments():
             attr="charging_time_left",
             name="Charging time left",
             icon="mdi:battery-charging-100",
-            unit="h",
+            unit="min",
             device_class="duration"
         ),
         Sensor(
@@ -1313,7 +1313,7 @@ def create_instruments():
             attr="climatisation_time_left",
             name="Climatisation time left",
             icon="mdi:clock",
-            unit="h",
+            unit="min",
             device_class="duration"
         ),
         Sensor(

--- a/skodaconnect/vehicle.py
+++ b/skodaconnect/vehicle.py
@@ -1836,18 +1836,19 @@ class Vehicle:
     @property
     def charging_time_left(self):
         """Return minutes to charging complete"""
-        if self.external_power:
+        if not self.external_power:
+            return 0
+        try:
             if self.attrs.get('charging', {}).get('remainingToCompleteInSeconds', False):
                 minutes = int(self.attrs.get('charging', {}).get('remainingToCompleteInSeconds', 0))/60
             elif self.attrs.get('charger', {}).get('status', {}).get('batteryStatusData', {}).get('remainingChargingTime', False):
                 minutes = self.attrs.get('charger', {}).get('status', {}).get('batteryStatusData', {}).get('remainingChargingTime', {}).get('content', 0)
-            try:
-                if minutes == -1: return '00:00'
-                if minutes == 65535: return '00:00'
-                return "%02d:%02d" % divmod(minutes, 60)
-            except Exception:
-                pass
-        return '00:00'
+            if not 0 <= minutes < 65535:
+                return 0
+            return minutes
+        except Exception:
+            pass
+        return 0
 
     @property
     def is_charging_time_left_supported(self):
@@ -2164,16 +2165,16 @@ class Vehicle:
 
     @property
     def climatisation_time_left(self):
-        """Return time left for climatisation in hours:minutes."""
+        """Return time left for climatisation in minutes."""
         if self.attrs.get('airConditioning', {}).get('remainingTimeToReachTargetTemperatureInSeconds', False):
             try:
                 minutes = int(self.attrs.get('airConditioning', {}).get('remainingTimeToReachTargetTemperatureInSeconds', 0))/60
                 if not 0 <= minutes <= 65535:
-                    return "00:00"
-                return "%02d:%02d" % divmod(minutes, 60)
+                    return 0
+                return minutes
             except Exception:
                 pass
-        return "00:00"
+        return 0
 
     @property
     def is_climatisation_time_left_supported(self):
@@ -2964,7 +2965,7 @@ class Vehicle:
     @property
     def trip_cyclic_entry(self):
         return self.attrs.get('cyclicstatistics', {})
-        
+
     @property
     def trip_last_average_speed(self):
         return self.trip_last_entry.get('averageSpeed')


### PR DESCRIPTION
These sensors have device_class=duration so we should return an int of float with a duration unit, and not a formatted 'hh:mm' string. This will allow HA to correctly display the duration and also allow to use the sensor value in automations/calculations.

Fixes skodaconnect/homeassistant-skodaconnect#195