### PR TITLE
Handle missing JSON in error response

### DIFF
--- a/skodaconnect/connection.py
+++ b/skodaconnect/connection.py
@@ -1983,9 +1983,8 @@ class Connection:
                     _LOGGER.debug(f'Response JSON: {error}')
                     raise SkodaException('Failed token refresh')
             else:
-                resp = await response.json()
                 _LOGGER.warning(f'Something went wrong when refreshing tokens for "{client}".')
-                _LOGGER.debug(f'Response JSON: {resp}')
+                _LOGGER.debug(f'Response: {response}')
         except Exception as error:
             _LOGGER.warning(f'Could not refresh tokens: {error}')
         return False


### PR DESCRIPTION
We were getting:

```
2023-10-25 08:48:46.909 WARNING (MainThread) [skodaconnect.connection] Could not refresh tokens: 0, message='Attempt to decode JSON with unexpected mimetype: text/html', url=URL('https://api.connect.skoda-auto.cz/api/v1/authentication/token/refresh?systemId=CONNECT')
```

API endpoint is currently dead and we're getting 503's, which don't have a JSON payload.

Now:

```
2023-10-25 18:59:38.978 DEBUG (MainThread) [skodaconnect.connection] No valid access token for "connect"
2023-10-25 18:59:38.978 DEBUG (MainThread) [skodaconnect.connection] Refreshing tokens for client "connect"
2023-10-25 18:59:39.006 WARNING (MainThread) [skodaconnect.connection] Something went wrong when refreshing tokens for "connect".
2023-10-25 18:59:39.010 DEBUG (MainThread) [skodaconnect.connection] Response JSON: <ClientResponse(https://api.connect.skoda-auto.cz/api/v1/authentication/token/refresh?systemId=CONNECT) [503 Service Temporarily Unavailable]>
<CIMultiDictProxy('Date': 'Wed, 25 Oct 2023 18:59:38 GMT', 'Content-Type': 'text/html', 'Content-Length': '190', 'Connection': 'keep-alive', 'Strict-Transport-Security': 'max-age=15724800; includeSubDomains', 'Expect-CT': 'max-age=0, enforce', 'Trace-id': 'd634d1ba4d994ace4b18e400202aede8')>
```