### PR TITLE
Keep UTC time zone attached to datetime objects when API returns timestamps in UTC.

### DIFF
--- a/skodaconnect/vehicle.py
+++ b/skodaconnect/vehicle.py
@@ -1531,15 +1531,15 @@ class Vehicle:
         if self.attrs.get('StoredVehicleDataResponse', False):
             last_connected_utc = self.attrs.get('StoredVehicleDataResponse').get('vehicleData').get('data')[0].get('field')[0].get('tsCarSentUtc')
             if isinstance(last_connected_utc, datetime):
-                last_connected = last_connected_utc.astimezone().replace(tzinfo=None)
+                last_connected = last_connected_utc
             else:
-                last_connected = datetime.strptime(last_connected_utc,'%Y-%m-%dT%H:%M:%SZ').astimezone().replace(tzinfo=None)
+                last_connected = datetime.fromisoformat(last_connected_utc)
         elif self.attrs.get('vehicle_remote', False):
             last_connected_utc = self.attrs.get('vehicle_remote', {}).get('capturedAt', None)
             if isinstance(last_connected_utc, datetime):
-                last_connected = last_connected_utc.astimezone().replace(tzinfo=None)
+                last_connected = last_connected_utc
             elif isinstance(last_connected_utc, str):
-                last_connected = datetime.strptime(last_connected_utc,'%Y-%m-%dT%H:%M:%S.%fZ').astimezone().replace(tzinfo=None).replace(microsecond=0)
+                last_connected = datetime.fromisoformat(last_connected_utc)
             else:
                 return None
         return last_connected.isoformat()
@@ -1983,9 +1983,9 @@ class Vehicle:
         """Return timestamp of last parking time."""
         parkTime_utc = self.attrs.get('findCarResponse', {}).get('parkingTimeUTC', 'Unknown')
         if isinstance(parkTime_utc, datetime):
-            parkTime = parkTime_utc.astimezone().replace(tzinfo=None)
+            parkTime = parkTime_utc
         else:
-            parkTime = datetime.strptime(parkTime_utc,'%Y-%m-%dT%H:%M:%SZ').astimezone().replace(tzinfo=None)
+            parkTime = datetime.fromisoformat(parkTime_utc)
         return parkTime.isoformat()
 
     @property


### PR DESCRIPTION
This fixes https://github.com/skodaconnect/homeassistant-skodaconnect/issues/225

**Important:** this will only work on Python 3.11 and higher because prior to 3.11 this method only supported formats that could be emitted by [date.isoformat()](https://docs.python.org/3/library/datetime.html#datetime.date.isoformat) or [datetime.isoformat()](https://docs.python.org/3/library/datetime.html#datetime.datetime.isoformat). In Python 3.9 for example this code will fail to parse the timestamp returned by the API. I can replace this with `datetime.strptime(last_connected_utc,'%Y-%m-%dT%H:%M:%SZ').astimezone(timezone.utc)` which works in older versions. I'm not sure what is the expectation of Python version for this library.