### PR TITLE
Hotfix: don't send user-agent information to avoid 429 too many request error…

### DIFF
--- a/skodaconnect/connection.py
+++ b/skodaconnect/connection.py
@@ -332,7 +332,7 @@ class Connection:
                 _LOGGER.debug(f"Trying to authorize with {tokenBody}")
             newHeader = {
                 'Content-Type': "application/json; charset=UTF-8",
-                'user-agent': "okhttp/4.9.3"
+                #'user-agent': "okhttp/4.9.3" # sending user agent results into 429 status code
             }
             req = await self._session.post(
                 url=tokenURL,

--- a/skodaconnect/connection.py
+++ b/skodaconnect/connection.py
@@ -332,7 +332,7 @@ class Connection:
                 _LOGGER.debug(f"Trying to authorize with {tokenBody}")
             newHeader = {
                 'Content-Type': "application/json; charset=UTF-8",
-                #'user-agent': "okhttp/4.9.3" # sending user agent results into 429 status code
+                'User-Agent': USER_AGENT
             }
             req = await self._session.post(
                 url=tokenURL,

--- a/skodaconnect/const.py
+++ b/skodaconnect/const.py
@@ -50,7 +50,7 @@ HEADERS_SESSION = {
     'X-Client-Id': XCLIENT_ID,
     'X-App-Version': XAPPVERSION,
     'X-App-Name': XAPPNAME,
-    'User-Agent': USER_AGENT,
+    #'User-Agent': USER_AGENT,
     'tokentype': 'IDK_TECHNICAL'
 }
 

--- a/skodaconnect/const.py
+++ b/skodaconnect/const.py
@@ -38,7 +38,10 @@ CLIENT_LIST = {
 XCLIENT_ID = 'fef89b3d-a6e0-4525-91eb-a9436e6e469a'                                     # Used in Android app 5.2.7
 XAPPVERSION = '5.2.7'
 XAPPNAME = 'cz.skodaauto.connect'
-USER_AGENT = 'okhttp/4.9.3'
+# IOS App UA
+# USER_AGENT = 'MySkoda/230629002 CFNetwork/1474 Darwin/23.0.0'
+# Android App UA
+USER_AGENT = 'OneConnect/000000148 CFNetwork/1485 Darwin/23.1.0'
 APP_URI = 'skodaconnect://oidc.login/'
 
 # Used when fetching data
@@ -50,7 +53,7 @@ HEADERS_SESSION = {
     'X-Client-Id': XCLIENT_ID,
     'X-App-Version': XAPPVERSION,
     'X-App-Name': XAPPNAME,
-    #'User-Agent': USER_AGENT,
+    'User-Agent': USER_AGENT,
     'tokentype': 'IDK_TECHNICAL'
 }
 


### PR DESCRIPTION
This PR removes the user-agent header from the requests. This avoids the API to send a 429 response. 

I testet this within my own homeassist integration that uses this lib.  