### PR TITLE
Fix server address for realCarData request

### DIFF
--- a/skodaconnect/connection.py
+++ b/skodaconnect/connection.py
@@ -932,7 +932,7 @@ class Connection:
             subject = self.decode_token(atoken).get('sub', None)
 
             response = await self.get(
-                f'https://customer-profile.apps.emea.vwapps.io/v2/customers/{subject}/realCarData'
+                f'https://customer-profile.vwgroup.io/v2/customers/{subject}/realCarData'
             )
             if response.get('realCars', False):
                 data = {


### PR DESCRIPTION
The address has changed. The old one cannot be pinged, so most probably it does not exists.