### PR TITLE
Revert "Keep UTC time zone attached to datetime objects when API retu…

### DIFF
--- a/skodaconnect/vehicle.py
+++ b/skodaconnect/vehicle.py
@@ -1531,15 +1531,15 @@ class Vehicle:
         if self.attrs.get('StoredVehicleDataResponse', False):
             last_connected_utc = self.attrs.get('StoredVehicleDataResponse').get('vehicleData').get('data')[0].get('field')[0].get('tsCarSentUtc')
             if isinstance(last_connected_utc, datetime):
-                last_connected = last_connected_utc
+                last_connected = last_connected_utc.astimezone().replace(tzinfo=None)
             else:
-                last_connected = datetime.fromisoformat(last_connected_utc)
+                last_connected = datetime.strptime(last_connected_utc,'%Y-%m-%dT%H:%M:%SZ').astimezone().replace(tzinfo=None)
         elif self.attrs.get('vehicle_remote', False):
             last_connected_utc = self.attrs.get('vehicle_remote', {}).get('capturedAt', None)
             if isinstance(last_connected_utc, datetime):
-                last_connected = last_connected_utc
+                last_connected = last_connected_utc.astimezone().replace(tzinfo=None)
             elif isinstance(last_connected_utc, str):
-                last_connected = datetime.fromisoformat(last_connected_utc)
+                last_connected = datetime.strptime(last_connected_utc,'%Y-%m-%dT%H:%M:%S.%fZ').astimezone().replace(tzinfo=None).replace(microsecond=0)
             else:
                 return None
         return last_connected.isoformat()
@@ -1983,9 +1983,9 @@ class Vehicle:
         """Return timestamp of last parking time."""
         parkTime_utc = self.attrs.get('findCarResponse', {}).get('parkingTimeUTC', 'Unknown')
         if isinstance(parkTime_utc, datetime):
-            parkTime = parkTime_utc
+            parkTime = parkTime_utc.astimezone().replace(tzinfo=None)
         else:
-            parkTime = datetime.fromisoformat(parkTime_utc)
+            parkTime = datetime.strptime(parkTime_utc,'%Y-%m-%dT%H:%M:%SZ').astimezone().replace(tzinfo=None)
         return parkTime.isoformat()
 
     @property


### PR DESCRIPTION
@badrpc FYI - have to revert this so we can safely release a fix for the user-agent

This reverts commit 02c9c844899247d24fb5a85780d80df4edd8a629.

Throws the following exception on Enyaq for Webspider:

```
Traceback (most recent call last):
  File "/home/nivo/dev/skodaconnect/example/me.py", line 358, in <module>
    loop.run_until_complete(main())
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/home/nivo/dev/skodaconnect/example/me.py", line 247, in main
    print(f'\tstr_state: {instrument.str_state} - state: {instrument.state}')
  File "/home/nivo/dev/skodaconnect/skodaconnect/dashboard.py", line 123, in str_state
    return f'{self.state}'
  File "/home/nivo/dev/skodaconnect/skodaconnect/dashboard.py", line 127, in state
    val = super().state
  File "/home/nivo/dev/skodaconnect/skodaconnect/dashboard.py", line 58, in state
    if hasattr(self.vehicle, self.attr):
  File "/home/nivo/dev/skodaconnect/skodaconnect/vehicle.py", line 1542, in last_connected
    last_connected = datetime.fromisoformat(last_connected_utc)
ValueError: Invalid isoformat string: '2023-12-11T15:34:24.425Z'
```